### PR TITLE
Fixed a typo in file name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+## Repository
+
+Root directory contains Atollic TrueSTUDIO and STM32CubeMX project. NodeMCU Lua code can be found in [`NodeMCU`](./NodeMCU) directory.
+
+## You want to make it yourself?
 # Simple, yet overkilled, weather station
 
 ## Description
@@ -46,4 +51,4 @@ Okay, no problem. You can find STM32 pinout by opening the project in STM32CubeM
 
 ESP8266 pinout is basically RX and TX connected to STM32 TX and RX.
 
-Also, make sure to create `credentails.lua` file with `SSID` and `PASSWORD` variables for your WiFi connection, and upload it to ESP. Obviously, i'm not including mine.
+Also, make sure to create `credentials.lua` file with `SSID` and `PASSWORD` variables for your WiFi connection, and upload it to ESP. Obviously, i'm not including mine.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
-## Repository
-
-Root directory contains Atollic TrueSTUDIO and STM32CubeMX project. NodeMCU Lua code can be found in [`NodeMCU`](./NodeMCU) directory.
-
-## You want to make it yourself?
 # Simple, yet overkilled, weather station
 
 ## Description


### PR DESCRIPTION
`credentails.lua` -> `credentials.lua`